### PR TITLE
Update Gradle Wrapper from 8.0.1 to 8.0.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=948d1e4ccc2f6ae36cbfa087d827aaca51403acae5411e664a6000bb47946f22
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
+distributionSha256Sum=47a5bfed9ef814f90f8debcbbb315e8e7c654109acd224595ea39fca95c5d4da
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle Wrapper from 8.0.1 to 8.0.2.

Read the release notes: https://docs.gradle.org/8.0.2/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `8.0.2`
- Distribution (-all) zip checksum: `47a5bfed9ef814f90f8debcbbb315e8e7c654109acd224595ea39fca95c5d4da`
- Wrapper JAR Checksum: `91941f522fbfd4431cf57e445fc3d5200c85f957bda2de5251353cf11174f4b5`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>