### PR TITLE
Replace workflow implementation (#88)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,76 +1,26 @@
+name: Continuous Integration
+
 on:
   pull_request:
-    branches: ['main']
     types: [ opened, synchronize, reopened, ready_for_review ]
-    paths-ignore:
-      - '**.md'
   pull_request_target:
     types: [ opened, synchronize, reopened, ready_for_review ]
-    paths-ignore:
-      - '**.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  ci:
-    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
-    # Otherwise, clone it normally.
-    if: |
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Install Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-
-      - name: Git Checkout
-        uses: actions/checkout@v4
-        # Do not trigger a checkout when opening PRs from a fork (helps avoid
-        # "pwn request". See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target )
-        if: github.event_name != 'pull_request_target'
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-
-      - name: Dependabot Checkout
-        uses: actions/checkout@v4
-        if: github.event_name == 'pull_request_target'
-        with:
-          # Dependabot can only check out at the HEAD of the PR branch
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Gradle Build
-        id: build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew openApiGenerate build
-
+  pipeline:
+    uses: yonatankarp/github-actions/.github/workflows/ci.yml@v1
+    with:
+      context: .
+      build_dockerfile: false
 
   dependabot_auto_merge:
+    needs: pipeline
     if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
-    needs: ci
-    steps:
-      # If the PR is created by Dependabot run additional steps
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v1.6.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+    uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v1
 
-      - name: Approve a Dependabot PR
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
-        # Approving the PR and waiting for 5 sec to let GitHub UI to reflect the changes
-        run: gh pr review --approve "$PR_URL" && sleep 5
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.REVIEWER_GITHUB_TOKEN }}
-
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
-        run: gh pr merge --auto --rebase "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  linters:
+    uses: yonatankarp/github-actions/.github/workflows/linters.yml@v1

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -7,27 +7,4 @@ on:
 
 jobs:
   update-gradle-wrapper:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout PR
-        if: ${{ github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-
-      - name: Update Gradle Wrapper
-        # WARN: as this action comes from the org without public members and it has relatively few "stars",
-        # so this specific SHA passed #infosec review from SumUp. Please do NOT upgrade this version unless
-        # it is incompatible with our build - then we'll have to review the version diff.
-        uses: gradle-update/update-gradle-wrapper-action@0407394b9d173dfc9cf5695f9f560fef6d61a5fe
-        env:
-          POS_PACKAGES_READ_TOKEN: ${{ secrets.CATALOG_BOT_READ_PACKAGE_GH_TOKEN }}
-        with:
-          repo-token: ${{ secrets.REVIEWER_GITHUB_TOKEN }}
+    uses:  yonatankarp/github-actions/.github/workflows/update-gradle-wrapper.yml@v1


### PR DESCRIPTION
Replace workflow implementation

This commit replaces the current implementation of workflows with the remote one stored at `yonatankarp/github-actions` so each change there would automatically apply to all projects in my account