### PR TITLE
Fix dependabot auto-merge

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,8 +3,6 @@ name: Continuous Integration
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
-  pull_request_target:
-    types: [ opened, synchronize, reopened, ready_for_review ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
@@ -19,10 +17,13 @@ jobs:
 
   dependabot_auto_merge:
     needs: pipeline
-    if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
     uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v1
     secrets:
-      GITHUB_PAT: ${{ secrets.REVIEWER_GITHUB_TOKEN }}
+      DEPENDABOT_MERGE_TOKEN: ${{ secrets.REVIEWER_GITHUB_TOKEN }}
 
   linters:
     uses: yonatankarp/github-actions/.github/workflows/linters.yml@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Security
  - Reduced exposure by removing the target-based PR workflow trigger.
  - Applied least-privilege permissions to the Dependabot auto-merge job.

- Chores
  - Streamlined PR workflow to run only on standard pull request events.
  - Updated auto-merge conditions to rely on the Dependabot actor.
  - Standardized the token used for Dependabot merges.
  - No changes to existing linting or pipeline jobs.

- No User-Facing Changes
  - Application behavior and UI remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->