### PR TITLE
Fix Dependabot auto-merge

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
     uses: yonatankarp/github-actions/.github/workflows/ci.yml@v2
 
   dependabot_auto_merge:
-    needs: pipeline
+    needs: [ pipeline, linters ]
     if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       contents: write


### PR DESCRIPTION
Fix Dependabot auto-merge wiring based on fresh GitHub API/check-log evidence. Keeps the shared reusable workflow in use; repo-local changes only correct dependency ordering or missing wiring.